### PR TITLE
feat: add trait for stalkable model

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -22,6 +22,11 @@
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
 
+    <!-- Ignore Single class per file for tests -->
+    <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+
     <!-- Ignore inline controler structures not allowed -->
     <rule ref="Generic.ControlStructures.InlineControlStructure.NotAllowed">
         <exclude-pattern>*</exclude-pattern>

--- a/src/HasStalkerEntries.php
+++ b/src/HasStalkerEntries.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Theomessin\Stalker;
+
+trait HasStalkerEntries
+{
+    public function stalkerEntries()
+    {
+        return $this->morphMany(StalkerEntry::class, 'stalkable');
+    }
+}

--- a/tests/Feature/HasStalkerEntriesTest.php
+++ b/tests/Feature/HasStalkerEntriesTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Theomessin\Stalker\Tests\Feature;
+
+use Illuminate\Foundation\Auth\User as AuthUser;
+use Theomessin\Stalker\HasStalkerEntries;
+use Theomessin\Stalker\Tests\TestCase;
+
+class HasStalkerEntriesTest extends TestCase
+{
+    /** @test */
+    public function class_with_trait_can_retrieve_stalker_entries()
+    {
+        $user = User::find($this->user->id);
+        // Arrange: create an entry for this user.
+        $this->actingAs($user)->post('protected')->assertSuccessful();
+
+        // Act: get the Stalker entries for the user.
+        $entry = $user->stalkerEntries()->firstOrFail();
+
+        // Assert: the entry was correctly created.
+        $this->assertEquals('http://localhost/protected', $entry->url);
+        $this->assertEquals('POST', $entry->method);
+        $this->assertEquals('127.0.0.1', $entry->ip_address);
+    }
+}
+
+class User extends AuthUser
+{
+    use HasStalkerEntries;
+}

--- a/tests/Feature/StalkerMiddlewareTest.php
+++ b/tests/Feature/StalkerMiddlewareTest.php
@@ -5,7 +5,7 @@ namespace Theomessin\Stalker\Tests\Feature;
 use Theomessin\Stalker\StalkerEntry;
 use Theomessin\Stalker\Tests\TestCase;
 
-class StalkerTest extends TestCase
+class StalkerMiddlewareTest extends TestCase
 {
     /** @test */
     public function it_creates_entry_for_staked_route()


### PR DESCRIPTION
The HasStalkerEntries trait can be applied to the User model to easily
fetch StalkerEntries for that user.